### PR TITLE
Remove logging from TLS authentications

### DIFF
--- a/radius/sites-enabled/default
+++ b/radius/sites-enabled/default
@@ -44,9 +44,6 @@ accounting {
 session {
 }
 post-auth {
- if (EAP-Type == TLS)  {
-   rest
- }
 }
 pre-proxy {
 }


### PR DESCRIPTION
We are debugging Windows failed authentications.  It looks like Radius
is returning an Access Accept but the logging API is throwing a 404 when
trying to record the authentication.

Don't log TLS requests as a test to see if this fixes the issue on
Windows