### PR TITLE
Re-enable logging for EAP-TLS

### DIFF
--- a/radius/sites-enabled/default
+++ b/radius/sites-enabled/default
@@ -44,6 +44,9 @@ accounting {
 session {
 }
 post-auth {
+ if (EAP-Type == TLS)  {
+   rest
+ }
 }
 pre-proxy {
 }


### PR DESCRIPTION
The logging API will never return 404 responses which was preventing
certificate authentication on Windows due to the way it populated the
username.  We can safely re-enable logging for EAP-TLS