### PR TITLE
Move authorize REST call to after EAP

### DIFF
--- a/radius/sites-enabled/inner-tunnel
+++ b/radius/sites-enabled/inner-tunnel
@@ -1,10 +1,10 @@
 server inner-tunnel {
 authorize {
 	filter_username
-	rest
 	eap {
 		ok = return
 	}
+	rest
 }
 authenticate {
 	Auth-Type MS-CHAP {


### PR DESCRIPTION
We want to see if the eap authentication succeeds before calling out to
our backend API.  The way EAP-PEAP works is that it will call our API
multiple (3) times to do the authentication.  By moving this rest call to
below the PEAP authorization we will reduce the number of calls to 2.

Getting this down to 1 is a future task, which requires changes to the
frontend configuration which is quite complex.