### PR TITLE
only bind ports in development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 
 
-DOCKER_COMPOSE = docker-compose
+DOCKER_COMPOSE = docker-compose -f docker-compose.yml
+
+ifndef JENKINS_URL
+  DOCKER_COMPOSE += -f docker-compose.development.yml
+endif
+
 RUN_APP = ${DOCKER_COMPOSE} run --rm app
 RUN_APP_PORTS = ${DOCKER_COMPOSE} run --rm --service-ports app
+
 
 build: docker-build
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,8 @@
+version: "3.4"
+
+services:
+  app:
+    ports:
+      - "3000"
+      - "1812/udp"
+      - "1813/udp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       args:
         BUNDLE_ARGS: "--no-cache --no-prune --jobs=8"
-    ports:
+    expose:
       - "3000"
       - "1812/udp"
       - "1813/udp"


### PR DESCRIPTION
We only want to bind ports while in development, to avoid doing it for in jenkins.

This will allow us to run the tests in parallel