### PR TITLE
Format called and calling station IDs (MAC address)

### DIFF
--- a/radius/mods-enabled/rest
+++ b/radius/mods-enabled/rest
@@ -10,6 +10,8 @@ rest {
     logging_api_base_url = "$ENV{LOGGING_API_BASE_URL}"
 
     authorize {
+        rewrite_called_station_id
+        rewrite_calling_station_id
         uri = "${..authorisation_api_base_url}/authorize/user/%{User-Name}/mac/%{Calling-Station-ID}/ap/%{Called-Station-ID}/site/%{Client-IP-Address}/apg/%{Aruba-AP-Group}/mdn/%{Meraki-Device-Name}"
         method = 'get'
         body = 'json'

--- a/radius/policy.d/canonicalization
+++ b/radius/policy.d/canonicalization
@@ -1,0 +1,49 @@
+#
+#  Normalize the MAC Addresses in the Calling/Called-Station-Id
+#
+mac-addr-regexp = '([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})'
+
+#
+#  Add "rewrite_called_station_id" in the "authorize" and
+#  "preacct" sections.
+#
+#  Makes Called-Station-ID conform to what RFC3580 says should
+#  be provided by 802.1X authenticators.
+#
+rewrite_called_station_id {
+	if (&Called-Station-Id && (&Called-Station-Id =~ /^${policy.mac-addr-regexp}([^0-9a-f](.+))?$/i)) {
+		update request {
+			&Called-Station-Id := "%{toupper:%{1}-%{2}-%{3}-%{4}-%{5}-%{6}}"
+		}
+
+		# SSID component?
+		if ("%{8}") {
+			update request {
+				&Called-Station-SSID := "%{8}"
+			}
+		}
+		updated
+	}
+	else {
+		noop
+	}
+}
+
+#
+#  Add "rewrite_calling_station_id" in the "authorize" and
+#  "preacct" sections.
+#
+#  Makes Calling-Station-ID conform to what RFC3580 says should
+#  be provided by 802.1X authenticators.
+#
+rewrite_calling_station_id {
+	if (&Calling-Station-Id && (&Calling-Station-Id =~ /^${policy.mac-addr-regexp}$/i)) {
+		update request {
+			&Calling-Station-Id := "%{toupper:%{1}-%{2}-%{3}-%{4}-%{5}-%{6}}"
+		}
+		updated
+	}
+	else {
+		noop
+	}
+}


### PR DESCRIPTION
An admin user requested that we format the MAC addresses "A1:B2:C3..." rather than the current "A1-B2-C3". 

According to the standard the hyphen separated version ("-") is the correct way: https://tools.ietf.org/html/rfc3580

This PR implements the formatting of MAC addresses in FreeRADIUS: https://github.com/FreeRADIUS/freeradius-server/blob/v3.0.x/raddb/policy.d/canonicalization#L102

This would mean we can remove the logic in the logging API that currently does the formatting: https://github.com/alphagov/govwifi-logging-api/blob/master/lib/mac_formatter.rb

Changes to Logging API: https://github.com/alphagov/govwifi-logging-api/pull/131