### PR TITLE
avoid moving directories, instead remove it fully

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache add \
 # Set up the radius configs
 
 RUN mkdir /tmp/radiusd
-RUN mv /etc/raddb /etc/raddb.old
+RUN rm -rf /etc/raddb && mkdir -p /etc/raddb
 COPY radius /etc/raddb
 RUN openssl dhparam -out /etc/raddb/certs/dh 1024
 


### PR DESCRIPTION
the `img` tool fails if we move the directory. I'll raise an issue to them.

Given that we don't need to persist the directory, we can just remove it, and it seems happy enough.

```
failed to solve: failed calculating diff pairs for exported snapshot: mount callback failed on /run/user/1000/containerd-mount168630293: mount callback failed on /run/user/1000/containerd-mount728698480: failed to write compressed diff: failed to create diff tar stream: stat /run/user/1000/containerd-mount728698480/etc/raddb: no such file or directory
```