### PR TITLE
Fix pr pipeline yml

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -45,6 +45,35 @@ resources:
       repository: alpine
       tag: '3.8'
 
+update-status-commands:
+   update-status-base: &update-status-base
+     put: update-status
+     resource: pull-request
+     get_params:
+       skip_download: true
+
+   update-status-params-base: &update-status-params-base
+     path: src
+     context: 'pr'
+
+   update-status-pending: &update-status-pending
+     <<: *update-status-base
+     params:
+       <<: *update-status-params-base
+       status: pending
+
+   update-status-failure: &update-status-failure
+     <<: *update-status-base
+     params:
+       <<: *update-status-params-base
+       status: failure
+
+   update-status-success: &update-status-success
+     <<: *update-status-base
+     params:
+       <<: *update-status-params-base
+       status: success
+
 jobs:
   - name: self-update
     serial: true
@@ -106,31 +135,3 @@ jobs:
       do:
         - <<: *update-status-success
 
-update-status-commands:
-  update-status-base: &update-status-base
-    put: update-status
-    resource: pull-request
-    get_params:
-      skip_download: true
-
-  update-status-params-base: &update-status-params-base
-    path: src
-    context: 'pr'
-
-  update-status-pending: &update-status-pending
-    <<: *update-status-base
-    params:
-      <<: *update-status-params-base
-      status: pending
-
-  update-status-failure: &update-status-failure
-    <<: *update-status-base
-    params:
-      <<: *update-status-params-base
-      status: failure
-
-  update-status-success: &update-status-success
-    <<: *update-status-base
-    params:
-      <<: *update-status-params-base
-      status: success


### PR DESCRIPTION
An update to the version of Concourse (and Fly CLI) used to
parse self updating pipelines introduced a change to the way
yaml files are parsed. Anchors must be declared before they are
used.