### PR TITLE
Download radius config and certs via aws cli on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,19 @@
 FROM ruby:2.6.3-alpine3.8
 
-EXPOSE 1812/udp 1813/udp 3000
-
-RUN apk --no-cache add \
-      wpa_supplicant freeradius freeradius-rest freeradius-eap openssl \
-      make gcc libc-dev python3 && \
-      pip3 install awscli
-
 # Set up the radius configs
-
-RUN mkdir /tmp/radiusd
-RUN rm -rf /etc/raddb && mkdir -p /etc/raddb
+RUN apk --no-cache add wpa_supplicant freeradius freeradius-rest freeradius-eap openssl make gcc libc-dev \
+ && mkdir -p /tmp/radiusd /etc/raddb \
+ && openssl dhparam -out /etc/raddb/dh 1024
 COPY radius /etc/raddb
-RUN openssl dhparam -out /etc/raddb/certs/dh 1024
 
 # Set up the healtcheck service
-
 ARG BUNDLE_ARGS="--deployment --no-cache --no-prune --jobs=8 --without test"
-
 WORKDIR /usr/src/healthcheck
 COPY healthcheck/Gemfile* healthcheck/.ruby-version ./
-RUN bundle install $BUNDLE_ARGS
+RUN bundle install $BUNDLE_ARGS \
+ && apk del make gcc libc-dev
 COPY healthcheck ./
 
-# these were needed while bundling, but no longer
-RUN apk del make gcc libc-dev
-
-# ensure we're in the correct workdir at the end
-WORKDIR /usr/src/healthcheck
-
-# set up envs we need
-## healtcheck
-ENV HEALTH_CHECK_IDENTITY ""
-ENV HEALTH_CHECK_PASSWORD ""
-ENV HEALTH_CHECK_RADIUS_KEY ""
-ENV HEALTH_CHECK_SSID ""
-
-## radius fetched files
-ENV CERT_STORE_BUCKET ""
-ENV WHITELIST_BUCKET ""
-ENV ENDPOINT_URL ""
-
-## radius envs
-ENV AUTHORISATION_API_BASE_URL ""
-ENV LOGGING_API_BASE_URL ""
-ENV RADIUSD_PARAMS ""
-
-CMD [ "/bin/sh", "-c", \
-      "ENDPOINT_ARG=${ENDPOINT_URL:+--endpoint-url=$ENDPOINT_URL}; \
-      aws ${ENDPOINT_ARG} s3 cp ${WHITELIST_BUCKET}/clients.conf /etc/raddb/clients.conf; \
-      aws ${ENDPOINT_ARG} s3 cp ${CERT_STORE_BUCKET}/ca.pem /etc/raddb/certs/ca.pem; \
-      aws ${ENDPOINT_ARG} s3 cp ${CERT_STORE_BUCKET}/comodoCA.pem /etc/raddb/certs/comodoCA.pem; \
-      aws ${ENDPOINT_ARG} s3 cp ${CERT_STORE_BUCKET}/server.key /etc/raddb/certs/server.key; \
-      aws ${ENDPOINT_ARG} s3 cp ${CERT_STORE_BUCKET}/server.pem /etc/raddb/certs/server.pem; \
-      bundle exec rackup -o 0.0.0.0 -p 3000 & /usr/sbin/radiusd $RADIUSD_PARAMS | cat" \
-      ]
+VOLUME /etc/raddb/certs
+EXPOSE 1812/udp 1813/udp 3000
+CMD bundle exec rackup -o 0.0.0.0 -p 3000 & /usr/sbin/radiusd ${RADIUSD_PARAMS:?Variable not set}

--- a/Dockerfile.raddb
+++ b/Dockerfile.raddb
@@ -1,0 +1,11 @@
+FROM python:3-alpine
+VOLUME /etc/raddb/certs
+RUN wget "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" \
+ && unzip awscli-bundle.zip \
+ && rm awscli-bundle.zip \
+ && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws \
+ && rm -r ./awscli-bundle
+COPY raddb.sh /raddb.sh
+RUN chmod +x /raddb.sh
+ENTRYPOINT ["/raddb.sh"]
+CMD [ "date" ]

--- a/raddb.sh
+++ b/raddb.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env ash
+
+set -o nounset -o errexit
+
+ENDPOINT_ARG=${ENDPOINT_URL:+--endpoint-url=$ENDPOINT_URL}
+CERTSDIR=${CERTSDIR:-/etc/raddb/certs}
+
+aws ${ENDPOINT_ARG} s3 cp ${WHITELIST_BUCKET}/clients.conf ${CERTSDIR}/clients.conf
+aws ${ENDPOINT_ARG} s3 cp ${CERT_STORE_BUCKET}/ca.pem ${CERTSDIR}/ca.pem
+aws ${ENDPOINT_ARG} s3 cp ${CERT_STORE_BUCKET}/comodoCA.pem ${CERTSDIR}/comodoCA.pem
+aws ${ENDPOINT_ARG} s3 cp ${CERT_STORE_BUCKET}/server.key ${CERTSDIR}/server.key
+aws ${ENDPOINT_ARG} s3 cp ${CERT_STORE_BUCKET}/server.pem ${CERTSDIR}/server.pem
+
+exec "$@"

--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -9,7 +9,7 @@
       		ca_file = ${certdir}/ca.pem
 			private_key_password = whatever
 			private_key_file = ${certdir}/server.key
-			dh_file = ${certdir}/dh
+			dh_file = ${raddbdir}/dh
 			random_file = /dev/urandom
 			check_crl = no
 			ca_path = ${cadir}

--- a/radius/radiusd.conf
+++ b/radius/radiusd.conf
@@ -105,5 +105,5 @@ policy {
 }
 
 $INCLUDE sites-enabled/
-$INCLUDE clients.conf
+$INCLUDE ${certdir}/clients.conf
 $INCLUDE healthcheck-clients.conf


### PR DESCRIPTION
The existing configuration uses an IP whitelist to restrict http access to the bucket. To run this container on Fargate we should use ECS task roles with relevant read-only permissions.

To allow local testing we have added an ENDPOINT_URL environment var. This allows the aws cli `--endpoint-url` option to be overridden to use a mock S3 container such as localstack. In production this will default to empty to use the config automatically resolved by the aws cli.

Acceptance tests have been updated to mock calls to s3 in the following pr: https://github.com/alphagov/govwifi-acceptance-tests/pull/23

Merge only when ecs task role with s3 bucket permissions has been applied to the task.