### PR TITLE
Roll back to Alpine 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.3-alpine3.9
+FROM ruby:2.6.3-alpine3.8
 
 EXPOSE 1812/udp 1813/udp 3000
 


### PR DESCRIPTION
freeradius-rest (r6) package in 3.9 contains a regression breaking validation of rest authentication responses. Causes health checks to fail. Rolling back until root cause can be established and fix applied.