### PR TITLE
FIX - Replace deprecated govuk-lint-ruby for rubocop-govuk

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@
 # However we need to keep the ruby files
 !.ruby-version
 !**/.ruby-version
+!.rubocop.yml
+!**/.rubocop.yml
 
 # Avoid copying generated WPA config
 healthcheck/peap-mschapv2.conf

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test: test-healthcheck test-radius
 ## healthcheck related tasks
 
 lint-healthcheck: build
-	${RUN_APP} bundle exec govuk-lint-ruby
+	${RUN_APP} bundle exec rubocop
 
 test-healthcheck:
 	@echo "no healthcheck tests yet"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ making changes to FreeRADIUS or the healthcheck service.
 Makefile targets are:
 
 - `make test` - Currently a no-op. Tests are located in the [acceptance-tests][acceptance-tests] repo
-- `make lint` - Runs linting on the healtcheck service, provided by `govuk-lint`
+- `make lint` - Runs linting on the healtcheck service, provided by `rubocop-govuk`
 
 ## How it pieces together
 

--- a/healthcheck/.rubocop.yml
+++ b/healthcheck/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_gem:
+  rubocop-govuk: 
+    - config/default.yml
+    - config/rails.yml

--- a/healthcheck/Gemfile
+++ b/healthcheck/Gemfile
@@ -1,10 +1,12 @@
-source 'http://rubygems.org'
-ruby File.read('.ruby-version').chomp
+# frozen_string_literal: true
 
-gem 'puma'
-gem 'sinatra'
+source "http://rubygems.org"
+ruby File.read(".ruby-version").chomp
+
+gem "puma"
+gem "sinatra"
 
 group :test do
-  gem 'govuk-lint'
-  gem 'rspec'
+  gem "rspec"
+  gem "rubocop-govuk"
 end

--- a/healthcheck/Gemfile.lock
+++ b/healthcheck/Gemfile.lock
@@ -3,17 +3,12 @@ GEM
   specs:
     ast (2.4.0)
     diff-lcs (1.3)
-    ffi (1.11.1)
-    govuk-lint (3.11.2)
-      rubocop (~> 0.64)
-      rubocop-rspec (~> 1.28)
-      scss_lint
-    jaro_winkler (1.5.3)
+    jaro_winkler (1.5.4)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.5.2)
-    parallel (1.17.0)
-    parser (2.6.3.0)
+    parallel (1.19.1)
+    parser (2.7.0.2)
       ast (~> 2.4.0)
     puma (4.3.1)
       nio4r (~> 2.0)
@@ -21,10 +16,6 @@ GEM
     rack-protection (2.0.8.1)
       rack
     rainbow (3.0.0)
-    rake (12.3.2)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -38,25 +29,24 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.71.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rspec (1.33.0)
-      rubocop (>= 0.60.0)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.1)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    rubocop-rspec (1.37.1)
+      rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.58.0)
-      rake (>= 0.9, < 13)
-      sass (~> 3.5, >= 3.5.5)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -69,9 +59,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk-lint
   puma
   rspec
+  rubocop-govuk
   sinatra
 
 RUBY VERSION

--- a/healthcheck/README.md
+++ b/healthcheck/README.md
@@ -18,11 +18,11 @@ All logs are sent to `STDOUT` which means, when running on EC2 instance, they wi
 
 ### Running the tests
 
-You can run the tests and linter with the following commands:
+You can run  linter with the following command:
 
 ```shell
-bundle exec rspec spec/
-bundle exec govwifi-ruby-lint
+cd ..
+make lint-healthcheck
 ```
 
 ### Serving the app locally

--- a/healthcheck/app.rb
+++ b/healthcheck/app.rb
@@ -1,28 +1,32 @@
-require 'sinatra/base'
-require 'logger'
+# frozen_string_literal: true
 
-require_relative './wpa_config.rb'
+require "sinatra/base"
+require "logger"
+
+require_relative "./wpa_config.rb"
 
 class App < Sinatra::Base
   configure do
     set(:wpa_config, Proc.new {
       WpaConfig.new(
-        File.join(root, 'peap-mschapv2.conf.erb'),
-        ssid: ENV['HEALTH_CHECK_SSID'],
-        identity: ENV['HEALTH_CHECK_IDENTITY'],
-        password: ENV['HEALTH_CHECK_PASSWORD'],
+        File.join(root, "peap-mschapv2.conf.erb"),
+        ssid: ENV["HEALTH_CHECK_SSID"],
+        identity: ENV["HEALTH_CHECK_IDENTITY"],
+        password: ENV["HEALTH_CHECK_PASSWORD"],
       )
     })
-    set :healt_check_key, ENV['HEALTH_CHECK_RADIUS_KEY']
+    set :healt_check_key, ENV["HEALTH_CHECK_RADIUS_KEY"]
   end
 
   configure :production, :staging, :development do
     enable :logging
   end
 
-  get '/' do
-    result = `eapol_test -r0 -t3 -c #{settings.wpa_config.path} -a 127.0.0.1 -s #{settings.healt_check_key}`
+  get "/" do
+    path = settings.wpa_config.path
+    health_check_key = settings.healt_check_key
+    result = `eapol_test -r0 -t3 -c #{path} -a 127.0.0.1 -s #{health_check_key}`
     last_result = result.split("\n").last
-    last_result == 'SUCCESS' ? 200 : 500
+    last_result == "SUCCESS" ? 200 : 500
   end
 end

--- a/healthcheck/config.ru
+++ b/healthcheck/config.ru
@@ -1,5 +1,7 @@
-require './app'
+# frozen_string_literal: true
 
-RACK_ENV = ENV['RACK_ENV'] ||= 'development'
+require "./app"
+
+RACK_ENV = ENV["RACK_ENV"] ||= "development"
 
 run App

--- a/healthcheck/wpa_config.rb
+++ b/healthcheck/wpa_config.rb
@@ -1,4 +1,6 @@
-require 'erb'
+# frozen_string_literal: true
+
+require "erb"
 
 class WpaConfig
   def initialize(template_path, ssid:, identity:, password:)
@@ -17,7 +19,7 @@ private
     erb = ERB.new(File.read(@template_path))
     erb.filename = @template_path
 
-    File.open(path, 'w+') do |f|
+    File.open(path, "w+") do |f|
       f.write(erb.result_with_hash(
                 ssid: ssid,
                 identity: identity,


### PR DESCRIPTION
See https://docs.publishing.service.gov.uk/manual/migrate-from-govuk-lint.html

Note how we are telling dockerignore not to ignore rubocop: without this, the checkstyle configurations wouldn't have been copied to the image.