### PR TITLE
Fix linting errors to allow update to Rubocop 3.10.0

### DIFF
--- a/healthcheck/app.rb
+++ b/healthcheck/app.rb
@@ -7,14 +7,17 @@ require_relative "./wpa_config.rb"
 
 class App < Sinatra::Base
   configure do
-    set(:wpa_config, Proc.new {
-      WpaConfig.new(
-        File.join(root, "peap-mschapv2.conf.erb"),
-        ssid: ENV["HEALTH_CHECK_SSID"],
-        identity: ENV["HEALTH_CHECK_IDENTITY"],
-        password: ENV["HEALTH_CHECK_PASSWORD"],
-      )
-    })
+    set(
+      :wpa_config,
+      proc {
+        WpaConfig.new(
+          File.join(root, "peap-mschapv2.conf.erb"),
+          ssid: ENV["HEALTH_CHECK_SSID"],
+          identity: ENV["HEALTH_CHECK_IDENTITY"],
+          password: ENV["HEALTH_CHECK_PASSWORD"],
+        )
+      },
+    )
     set :healt_check_key, ENV["HEALTH_CHECK_RADIUS_KEY"]
   end
 

--- a/healthcheck/wpa_config.rb
+++ b/healthcheck/wpa_config.rb
@@ -24,7 +24,7 @@ private
                 ssid: ssid,
                 identity: identity,
                 password: password,
-        ))
+              ))
     end
   end
 end


### PR DESCRIPTION
After this is merged, we should also be able to merge https://github.com/alphagov/govwifi-frontend/pull/77