### PR TITLE
Expose Radius Prometheus Exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ RUN bundle install $BUNDLE_ARGS \
 COPY healthcheck ./
 
 VOLUME /etc/raddb/certs
-EXPOSE 1812/udp 1813/udp 3000
+EXPOSE 1812/udp 1813/udp 3000 9812
 CMD bundle exec rackup -o 0.0.0.0 -p 3000 & /usr/sbin/radiusd ${RADIUSD_PARAMS}


### PR DESCRIPTION
Allows the prometheus server scrape freeradius log exporter metrics on
port 9812:/metrics