### PR TITLE
Add Docker Hub credentials and login command

### DIFF
--- a/ci/tasks/pre-build.yml
+++ b/ci/tasks/pre-build.yml
@@ -18,6 +18,8 @@ params:
   # Set this to custom image names for preloading the app image. see `docker-compose.concourse.yml`
   PREBUILT_TAG: 'app-prebuilt'
   PREBUILT_CACHED_DIR: 'docker-cache/app-prebuilt-cached'
+  DOCKER_HUB_USERNAME_ENV: '((docker_hub_username))'
+  DOCKER_HUB_AUTHTOKEN_ENV: '((docker_hub_authtoken))'
 
 run:
   path: docker-wrapper

--- a/ci/tasks/scripts/pre-build.sh
+++ b/ci/tasks/scripts/pre-build.sh
@@ -3,6 +3,7 @@
 set -e -u -o pipefail
 
 ./src/ci/tasks/scripts/with-docker.sh
+echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
 
 workspace_dir="${PWD}"
 prebuilt_dir="${workspace_dir}/docker-cache/${PREBUILT_TAG}"


### PR DESCRIPTION
Add credentials to `pre-build` so task can pull images from Docker Hub. Also update build script to include login step.

We need to do this because Docker Hub will introduce rate limiting on 1 November.

paired: @camdesgov & @sarahseewhy 