### PR TITLE
Fix Radius Errors By Explicitly Setting Alpine Docker Image to Version 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine
+FROM ruby:2.6.3-alpine3.8
 
 # Set up the radius configs
 RUN apk --no-cache add wpa_supplicant freeradius freeradius-rest freeradius-eap openssl make gcc libc-dev \


### PR DESCRIPTION
The freeradius-rest (r6) package in 3.9 contains a regression breaking validation of rest authentication responses. This causes health checks and perhaps other user requests to fail. Sticking at Alpine 3.8 until we have time to plan an in-depth investigation around this.

Error:
```
Malformed HTTP header: Status line too short
```
Issue first noticed:
https://github.com/alphagov/govwifi-frontend/pull/49

Issue raised on Free RADIUS project:
https://github.com/FreeRADIUS/freeradius-server/issues/2821

Paired with @sarahseewhy