### PR TITLE
Add the base image with Ruby installed from source

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,18 @@
+# WARNING: We must pin the Alpine version to 3.8 because freeradius-rest (r6) package in alpine-3.9 contains
+# a regression breaking validation of rest authentication responses. Causes health checks to fail.
+# This is a known issue with FreeRadius: https://github.com/FreeRADIUS/freeradius-server/issues/2821
+FROM alpine:3.8
+
+# Set up the radius configs. linux-headers and openssl-dev are needed for building Ruby.
+RUN apk --no-cache add wpa_supplicant freeradius freeradius-rest freeradius-eap openssl make gcc libc-dev linux-headers openssl-dev \
+ && mkdir -p /tmp/radiusd /etc/raddb \
+ && openssl dhparam -out /etc/raddb/dh 1024
+COPY radius /etc/raddb
+
+# Install Ruby (for running the healthcheck service)
+RUN wget https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz \
+  && tar xzvf ruby-2.7.2.tar.gz \
+  && cd ruby-2.7.2 \
+  && ./configure \
+  && make \
+  && make install


### PR DESCRIPTION
The base image will be used by the main Docker image later down the line. 

We are doing this so that we can build Ruby from source, so that we could decouple the dependency between Alpine and Ruby versions, which was the issue when using `ruby:{x.x.x}-alpine{y}` as the base image.

Note that this is a prerequisite for https://github.com/alphagov/govwifi-concourse-deploy-pipeline/pull/14