### PR TITLE
Allow a custom user to be tested

### DIFF
--- a/healthcheck/app.rb
+++ b/healthcheck/app.rb
@@ -15,7 +15,7 @@ class App < Sinatra::Base
         ssid: ENV["HEALTH_CHECK_SSID"],
         identity: ENV["HEALTH_CHECK_IDENTITY"],
         password: ENV["HEALTH_CHECK_PASSWORD"],
-      )
+      ),
     )
     set :health_check_key, ENV["HEALTH_CHECK_RADIUS_KEY"]
   end
@@ -41,12 +41,12 @@ class App < Sinatra::Base
     result
   end
 
-  private
+private
 
-    def eapol_test(path)
-      health_check_key = settings.health_check_key
-      result = `eapol_test -r0 -t3 -c #{path} -a 127.0.0.1 -s #{health_check_key}`
-      last_result = result.split("\n").last
-      last_result == "SUCCESS" ? 200 : 500
-    end
+  def eapol_test(path)
+    health_check_key = settings.health_check_key
+    result = `eapol_test -r0 -t3 -c #{path} -a 127.0.0.1 -s #{health_check_key}`
+    last_result = result.split("\n").last
+    last_result == "SUCCESS" ? 200 : 500
+  end
 end

--- a/healthcheck/app.rb
+++ b/healthcheck/app.rb
@@ -7,18 +7,17 @@ require_relative "./wpa_config.rb"
 
 class App < Sinatra::Base
   configure do
+    set :wpa_config_template, File.join(root, "peap-mschapv2.conf.erb")
     set(
       :wpa_config,
-      proc {
-        WpaConfig.new(
-          File.join(root, "peap-mschapv2.conf.erb"),
-          ssid: ENV["HEALTH_CHECK_SSID"],
-          identity: ENV["HEALTH_CHECK_IDENTITY"],
-          password: ENV["HEALTH_CHECK_PASSWORD"],
-        )
-      },
+      WpaConfig.new(
+        settings.wpa_config_template,
+        ssid: ENV["HEALTH_CHECK_SSID"],
+        identity: ENV["HEALTH_CHECK_IDENTITY"],
+        password: ENV["HEALTH_CHECK_PASSWORD"],
+      )
     )
-    set :healt_check_key, ENV["HEALTH_CHECK_RADIUS_KEY"]
+    set :health_check_key, ENV["HEALTH_CHECK_RADIUS_KEY"]
   end
 
   configure :production, :staging, :development do
@@ -26,10 +25,28 @@ class App < Sinatra::Base
   end
 
   get "/" do
-    path = settings.wpa_config.path
-    health_check_key = settings.healt_check_key
-    result = `eapol_test -r0 -t3 -c #{path} -a 127.0.0.1 -s #{health_check_key}`
-    last_result = result.split("\n").last
-    last_result == "SUCCESS" ? 200 : 500
+    eapol_test(settings.wpa_config.path)
   end
+
+  post "/" do
+    wpa_config = WpaConfig.new(
+      settings.wpa_config_template,
+      ssid: ENV["HEALTH_CHECK_SSID"],
+      identity: params[:identity],
+      password: params[:password],
+    )
+    result = eapol_test(wpa_config.path)
+    wpa_config.close
+
+    result
+  end
+
+  private
+
+    def eapol_test(path)
+      health_check_key = settings.health_check_key
+      result = `eapol_test -r0 -t3 -c #{path} -a 127.0.0.1 -s #{health_check_key}`
+      last_result = result.split("\n").last
+      last_result == "SUCCESS" ? 200 : 500
+    end
 end

--- a/healthcheck/wpa_config.rb
+++ b/healthcheck/wpa_config.rb
@@ -25,10 +25,10 @@ private
     erb.filename = @template_path
 
     @file.write(erb.result_with_hash(
-      ssid: ssid,
-      identity: identity,
-      password: password,
-    ))
+                  ssid: ssid,
+                  identity: identity,
+                  password: password,
+                ))
     @file.rewind
   end
 end

--- a/healthcheck/wpa_config.rb
+++ b/healthcheck/wpa_config.rb
@@ -5,12 +5,17 @@ require "erb"
 class WpaConfig
   def initialize(template_path, ssid:, identity:, password:)
     @template_path = template_path
+    @file = Tempfile.new(template_path)
     generate(ssid, identity, password)
   end
 
   def path
-    # hack, remove .erb
-    @template_path[0..-5]
+    @file.path
+  end
+
+  def close
+    @file.close
+    @file.unlink
   end
 
 private
@@ -19,12 +24,11 @@ private
     erb = ERB.new(File.read(@template_path))
     erb.filename = @template_path
 
-    File.open(path, "w+") do |f|
-      f.write(erb.result_with_hash(
-                ssid: ssid,
-                identity: identity,
-                password: password,
-              ))
-    end
+    @file.write(erb.result_with_hash(
+      ssid: ssid,
+      identity: identity,
+      password: password,
+    ))
+    @file.rewind
   end
 end


### PR DESCRIPTION
Adds a `POST /` route that accepts `identity`/`password`.

* Moved the compiled template into a tempfile. 
  * The default file is generated on launch, and is deleted when the process exits.
  *  When using custom identity, it's generated each time, and then deleted immediately after use.

Once this is on staging I can test the newly created credentials, however we still need to identify how we can expose the service to Concourse so that the smoke tests can pass in and test users.