### PR TITLE
changed default method to peap as ms-chap-v2 is invalid

### DIFF
--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -1,5 +1,5 @@
 	eap {
-		default_eap_type = mschapv2
+		default_eap_type = peap
 		timer_expire     = 60
 		ignore_unknown_eap_types = no
 		cisco_accounting_username_bug = no


### PR DESCRIPTION
**WHAT**

Change the default auth type from mschapv2 to peap

**WHY**

mschapv2 is invalid so clients attempt that, it fails and falls back to peap

changing this makes auth process about 5 times faster (0.02 secs instead of 0.10 secs)