### PR TITLE
Send the AWS Task ARN to the Logging API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk --no-cache add wpa_supplicant freeradius freeradius-rest freeradius-eap 
  && mkdir -p /tmp/radiusd /etc/raddb \
  && openssl dhparam -out /etc/raddb/dh 1024
 COPY radius /etc/raddb
+COPY ci/tasks/scripts/run.sh /usr/bin
 
 # Set up the healtcheck service
 ARG BUNDLE_ARGS="--deployment --no-cache --no-prune --jobs=8 --without test"
@@ -24,4 +25,4 @@ RUN chmod 755 /usr/sbin/freeradius_exporter
 
 VOLUME /etc/raddb/certs
 EXPOSE 1812/udp 1813/udp 3000 9812
-CMD bundle exec rackup -o 0.0.0.0 -p 3000 & /usr/sbin/radiusd ${RADIUSD_PARAMS} & freeradius_exporter -web.listen-address 0.0.0.0:9812
+CMD /usr/bin/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM ruby:2.6.3-alpine3.8
 
 # Set up the radius configs
-RUN apk --no-cache add wpa_supplicant freeradius freeradius-rest freeradius-eap openssl make gcc libc-dev \
+RUN apk --no-cache add wpa_supplicant freeradius freeradius-rest freeradius-eap openssl make gcc libc-dev curl jq \
  && mkdir -p /tmp/radiusd /etc/raddb \
  && openssl dhparam -out /etc/raddb/dh 1024
 COPY radius /etc/raddb

--- a/ci/tasks/scripts/run.sh
+++ b/ci/tasks/scripts/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle exec rackup -o 0.0.0.0 -p 3000 &
+/usr/sbin/radiusd ${RADIUSD_PARAMS} &
+freeradius_exporter -web.listen-address 0.0.0.0:9812

--- a/ci/tasks/scripts/run.sh
+++ b/ci/tasks/scripts/run.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ -n "${ECS_CONTAINER_METADATA_URI}" ]; then
+  export TASK_ID=$(curl $ECS_CONTAINER_METADATA_URI | jq '.Labels ."com.amazonaws.ecs.task-arn"')
+fi
+
 bundle exec rackup -o 0.0.0.0 -p 3000 &
 /usr/sbin/radiusd ${RADIUSD_PARAMS} &
 freeradius_exporter -web.listen-address 0.0.0.0:9812

--- a/radius/mods-enabled/rest
+++ b/radius/mods-enabled/rest
@@ -8,6 +8,7 @@ rest {
 
     authorisation_api_base_url = "$ENV{AUTHORISATION_API_BASE_URL}"
     logging_api_base_url = "$ENV{LOGGING_API_BASE_URL}"
+    task_id = "$ENV{TASK_ID}"
 
     authorize {
         uri = "${..authorisation_api_base_url}/authorize/user/%{User-Name}/mac/%{Calling-Station-ID}/ap/%{Called-Station-ID}/site/%{Client-IP-Address}/apg/%{Aruba-AP-Group}/mdn/%{Meraki-Device-Name}"
@@ -27,7 +28,7 @@ rest {
     post-auth {
         uri = "${..logging_api_base_url}/logging/post-auth"
         method = 'post'
-        data = '{ "username": "%{User-Name}", "mac": "%{Calling-Station-ID}", "called_station_id": "%{Called-Station-ID}", "site_ip_address": "%{Client-IP-Address}", "cert_name": "%{TLS-Client-Cert-Common-Name}", "authentication_result": "%{reply:Packet-Type}", "authentication_reply": "%{reply:Reply-Message}" }'
+        data = '{ "username": "%{User-Name}", "mac": "%{Calling-Station-ID}", "called_station_id": "%{Called-Station-ID}", "site_ip_address": "%{Client-IP-Address}", "cert_name": "%{TLS-Client-Cert-Common-Name}", "authentication_result": "%{reply:Packet-Type}", "authentication_reply": "%{reply:Reply-Message}", "task_id": "${..task_id}" }'
         body = 'json'
         tls = ${..tls}
     }


### PR DESCRIPTION
### What
Send the AWS Task ARN to the Logging API after each request to Radius

### Why
So that each request can be traced back to a particular Radius server so that we can improve our debugging.

Link to Trello card (if applicable): 
https://trello.com/c/876KuDU3/1442-add-a-column-to-the-sessions-table-for-the-radius-server-that-was-used-in-the-connection-to-be-listed-3