### PR TITLE
Use double quotes to allow for dynamic string expansion

### DIFF
--- a/radius/mods-enabled/rest
+++ b/radius/mods-enabled/rest
@@ -27,7 +27,7 @@ rest {
     post-auth {
         uri = "${..logging_api_base_url}/logging/post-auth"
         method = 'post'
-        data = '{ "username": "%{User-Name}", "mac": "%{Calling-Station-ID}", "called_station_id": "%{Called-Station-ID}", "site_ip_address": "%{Client-IP-Address}", "cert_name": "%{TLS-Client-Cert-Common-Name}", "authentication_result": "%{reply:Packet-Type}", "authentication_reply": "%{reply:Reply-Message}", "task_id": "$ENV{TASK_ID}" }'
+        data = "{ \"username\": \"%{User-Name}\", \"mac\": \"%{Calling-Station-ID}\", \"called_station_id\": \"%{Called-Station-ID}\", \"site_ip_address\": \"%{Client-IP-Address}\", \"cert_name\": \"%{TLS-Client-Cert-Common-Name}\", \"authentication_result\": \"%{reply:Packet-Type}\", \"authentication_reply\": \"%{reply:Reply-Message}\", \"task_id\": \"$ENV{TASK_ID}\" }"
         body = 'json'
         tls = ${..tls}
     }


### PR DESCRIPTION
Double quotes within the string need to be escaped.

