### PR TITLE
Remove double quotes on the TASK_ID variable

### DIFF
--- a/ci/tasks/scripts/run.sh
+++ b/ci/tasks/scripts/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -n "${ECS_CONTAINER_METADATA_URI}" ]; then
-  export TASK_ID=$(curl $ECS_CONTAINER_METADATA_URI | jq '.Labels ."com.amazonaws.ecs.task-arn"')
+  export TASK_ID=$(curl $ECS_CONTAINER_METADATA_URI | jq -r '.Labels ."com.amazonaws.ecs.task-arn"')
 fi
 
 bundle exec rackup -o 0.0.0.0 -p 3000 &


### PR DESCRIPTION
The -r (raw) option of jq removes double quotes around the output.