### PR TITLE
Chop up full ARN and keep only last part

### DIFF
--- a/ci/tasks/scripts/run.sh
+++ b/ci/tasks/scripts/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -n "${ECS_CONTAINER_METADATA_URI}" ]; then
-  export TASK_ID=$(curl $ECS_CONTAINER_METADATA_URI | jq -r '.Labels ."com.amazonaws.ecs.task-arn"')
+  export TASK_ID=$(echo $(curl $ECS_CONTAINER_METADATA_URI | jq -r '.Labels ."com.amazonaws.ecs.task-arn"') | tr "/" "\n" | tail -n 1)
 fi
 
 bundle exec rackup -o 0.0.0.0 -p 3000 &


### PR DESCRIPTION
### What

Chops up the task id and keeps just the last part before exporting to an environment variable, so that:

arn:aws:ecs:eu-west-2:XXXXXXXXXXXX:task/wifi-frontend-cluster/275ddf4dd4734c9fbe80036d3826cdfe

becomes:

275ddf4dd4734c9fbe80036d3826cdfe

It may be possible to simplify this a bit. However, various attempts to squash it into a single line caused bad substitution errors and, on the plus side, it's easier to follow split over three lines.

This is potentially vulnerable to any changes made by AWS to the ARN format but as long as the bit we need is the section following the final / in the full ARN, it will continue to work.

### Why

So that we're not logging AWS account numbers in the logging database or displaying them in the super-admin site.


Link to Trello card (if applicable): 

https://trello.com/c/q6Eu75fo/1503-prevent-recording-display-of-aws-account-numbers-in-super-admin-log-page