### PR TITLE
Revert "Fix typo in Docker file"

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM ruby:3.0.3-alpine
+FROM FROM ruby:3.0.3-alpine
 
 # Set up the radius configs. linux-headers and openssl-dev are needed for building Ruby.
 RUN apk --no-cache add wpa_supplicant freeradius freeradius-rest freeradius-eap openssl make gcc libc-dev linux-headers openssl-dev \


### PR DESCRIPTION
### What

Reverts alphagov/govwifi-frontend#163

### Why

We're in the process of reverting #163 and #161. Since these changes were deployed to production at 11AM we've seen an increase in the number of TLS errors in the `govwifi-frontend` logs:

```
eap_peap: ERROR: (TLS) Alert write:fatal:protocol version
eap_peap: ERROR: (TLS) Server : Error in error
```

Users have also reported authentication/connectivity issues with a subset of older Merakai access points with some indication that there's problem with TLS versions.
