### PR TITLE
Explicitly allow TLS version 1.0

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-11-13T16:48:10Z",
+  "generated_at": "2022-02-01T10:46:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -78,7 +78,7 @@
       {
         "hashed_secret": "d869db7fe62fb07c25a0403ecaea55031744b5fb",
         "is_verified": false,
-        "line_number": 10,
+        "line_number": 11,
         "type": "Secret Keyword"
       }
     ]

--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -5,8 +5,9 @@
 		cisco_accounting_username_bug = no
 		max_sessions = 4096
 		tls {
+			tls_min_version = "1.0"
 			certificate_file = ${certdir}/server.pem
-      		ca_file = ${certdir}/ca.pem
+			ca_file = ${certdir}/ca.pem
 			private_key_password = whatever
 			private_key_file = ${certdir}/server.key
 			dh_file = ${raddbdir}/dh
@@ -17,9 +18,9 @@
 			ecdh_curve = "prime256v1"
 
 			cache {
-			      enable = no
-			      lifetime = 24
-			      max_entries = 255
+				enable = no
+				lifetime = 24
+				max_entries = 255
 			}
 
 			verify {


### PR DESCRIPTION
Currently, we accept TLS version 1.0 implicitly. The version of TLS
we accept is determined by the version of Radius that is supplied
with the Docker images and what the default value is of the accepted
TLS version.

### Why
It is undesirable to have the version of Radius determine the version
of TLS we accept. Upgrading Radius in future may cause unexpected
behaviour.

Trello: https://trello.com/c/bKTP0yPE/1339-explicitly-allow-radius-to-accept-tls-10