### PR TITLE
Assert the freeradius version in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM ruby:2.6.3-alpine3.8
 
 # Set up the radius configs
-RUN apk --no-cache add wpa_supplicant freeradius freeradius-rest freeradius-eap openssl make gcc libc-dev curl jq \
+RUN apk --no-cache add wpa_supplicant freeradius~=3.0.17 freeradius-rest freeradius-eap openssl make gcc libc-dev curl jq \
  && mkdir -p /tmp/radiusd /etc/raddb \
  && openssl dhparam -out /etc/raddb/dh 1024
 COPY radius /etc/raddb


### PR DESCRIPTION
### What
Dockerfiles are awful, especially for composing different bits of
software. Changing the base image can affect the freeradius version
used.

This commit adds a version constraint to the freeradius.

The recent breaking change occurred between what I would consider
patch versions (3.0.17 to 3.0.25), so make the version quite specific.

### Why
So that changes to the freeradius version is intentional, add a
constraint to the freeradius package version in the Dockerfile.
