### PR TITLE
Switch to not using env in raddb.sh

### DIFF
--- a/raddb.sh
+++ b/raddb.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env ash -x
+#!/bin/ash -x
 
 set -o nounset -o errexit
 


### PR DESCRIPTION
### What
Switch to not using env in raddb.sh

### Why
It doesn't seem to work like the GNU env, so just call /bin/ash
directly.
