### PR TITLE
Introduce an AWS Codebuild Task

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,26 @@
+version: 0.2
+phases:
+    pre_build:
+        commands:
+            - echo "AWS_REGION is $AWS_REGION "
+            - REPOSITORY_URI_RADDB="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/$STAGE/raddb"
+            - echo "REPOSITORY_URI_RADDB is $REPOSITORY_URI_RADDB"
+            - REPOSITORY_URI_FE="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/$STAGE/frontend"
+            - echo "REPOSITORY_URI_FE is $REPOSITORY_URI_FE"
+            - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+    build:
+        commands:
+            - echo Build started on `date`
+            - echo "Building raddb Docker image..."
+            - docker build -t $REPOSITORY_URI_RADDB:latest -f Dockerfile.raddb .
+            - echo "Building frontend Docker image..."
+            - docker build -t $REPOSITORY_URI_FE:latest -f Dockerfile .
+    post_build:
+        commands:
+            - echo "Pushing the Docker images..."
+            - echo "Logging into AWS ECR"
+            - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+            - echo "Pushing raddb image"
+            - docker push $REPOSITORY_URI_RADDB:latest
+            - echo "Pushing frontend image"
+            - docker push $REPOSITORY_URI_FE:latest

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,19 +8,21 @@ phases:
             - REPOSITORY_URI_FE="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/$STAGE/frontend"
             - echo "REPOSITORY_URI_FE is $REPOSITORY_URI_FE"
             - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+            - IMAGE_TAG="latest"
+
     build:
         commands:
             - echo Build started on `date`
             - echo "Building raddb Docker image..."
-            - docker build -t $REPOSITORY_URI_RADDB:latest -f Dockerfile.raddb .
+            - docker build -t $REPOSITORY_URI_RADDB:$IMAGE_TAG -f Dockerfile.raddb .
             - echo "Building frontend Docker image..."
-            - docker build -t $REPOSITORY_URI_FE:latest -f Dockerfile .
+            - docker build -t $REPOSITORY_URI_FE:$IMAGE_TAG -f Dockerfile .
     post_build:
         commands:
             - echo "Pushing the Docker images..."
             - echo "Logging into AWS ECR"
             - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
             - echo "Pushing raddb image"
-            - docker push $REPOSITORY_URI_RADDB:latest
+            - docker push $REPOSITORY_URI_RADDB:$IMAGE_TAG
             - echo "Pushing frontend image"
-            - docker push $REPOSITORY_URI_FE:latest
+            - docker push $REPOSITORY_URI_FE:$IMAGE_TAG


### PR DESCRIPTION
### What
Introduce an AWS Codebuild task permitting us to migrate from concourse to AWS Developer Tools

### Why
We need to migrate away from Concourse due to strategic decision to use managed services.


### Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-253