### PR TITLE
Set default security level for OpenSSL

### DIFF
--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -14,7 +14,7 @@
 			random_file = /dev/urandom
 			check_crl = no
 			ca_path = ${cadir}
-			cipher_list = "DEFAULT"
+			cipher_list = "DEFAULT@SECLEVEL=0"
 			ecdh_curve = "prime256v1"
 
 			cache {


### PR DESCRIPTION
### What
Set default security level for OpenSSL

### Why
OpenSSL changed the default secuity level so that TLS 1.0 connections are not accepted. This change re-enables TLS 1.0.


Link to Trello card (if applicable):  https://technologyprogramme.atlassian.net/browse/GW-796
