### PR TITLE
Clear warnings when building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ruby:3.2.1-alpine3.17
 
 RUN apk --update --no-cache add wpa_supplicant openssl make gcc libc-dev curl talloc-dev jq g++ zlib-dev \
-                                openssl-dev linux-headers python3 py3-pip net-tools tmux sqlite-libs sqlite \
-                                sqlite-dev libxml2 curl-dev json-c-dev libmemcached-dev mariadb-connector-c-dev
+                                openssl-dev linux-headers python3 py3-pip py3-wheel net-tools tmux sqlite-libs \
+                                sqlite sqlite-dev libxml2 curl-dev json-c-dev libmemcached-dev \
+                                mariadb-connector-c-dev
 
 RUN wget https://github.com/FreeRADIUS/freeradius-server/releases/download/release_3_2_2/freeradius-server-3.2.2.tar.gz \
     && tar xzvf freeradius-server-3.2.2.tar.gz \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint: build
 	docker run $(DOCKER_FLAGS) --rm -v=$(CURDIR)/radius:/etc/raddb -v=$(CURDIR)/radius/certs:/etc/raddb/certs -p 1812-1813:1812-1813/udp -p 3000:3000 -p 9812:9812 govwifi-frontend /bin/sh -c "cd /healthcheck && bundle exec rubocop -d"
 
 build: FORCE
-	docker build $(DOCKER_FLAGS) -t govwifi-frontend .
+	docker build --progress=plain $(DOCKER_FLAGS) -t govwifi-frontend .
 
 serve: build FORCE
 	# Declare the /etc/radius/certs mount explicity, despite being a subdir of /etc/radius because it is declared

--- a/api-stubs/Gemfile.lock
+++ b/api-stubs/Gemfile.lock
@@ -103,4 +103,4 @@ RUBY VERSION
    ruby 3.2.1p31
 
 BUNDLED WITH
-   2.4.7
+   2.4.6

--- a/healthcheck/Gemfile.lock
+++ b/healthcheck/Gemfile.lock
@@ -82,4 +82,4 @@ RUBY VERSION
    ruby 3.2.1p31
 
 BUNDLED WITH
-   2.4.7
+   2.4.6

--- a/test-app/Gemfile.lock
+++ b/test-app/Gemfile.lock
@@ -100,4 +100,4 @@ RUBY VERSION
    ruby 3.2.1p31
 
 BUNDLED WITH
-   2.4.7
+   2.4.6


### PR DESCRIPTION
### What

Install the alpine py3-wheel package to clear warning from pip (installing wheel via pip doesn't achieve this). Use the same version of bundler that comes with the ruby-alpine build image.

Tweak the docker build command so warnings are easier to spot in future.

### Why

So we don't have needless build warnings which confuse debugging.

Link to Trello card (if applicable):  https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-796

