### PR TITLE
Fix critical issue with radius docker image

### DIFF
--- a/Dockerfile.raddb
+++ b/Dockerfile.raddb
@@ -1,10 +1,6 @@
 FROM python:3-alpine
 VOLUME /etc/raddb/certs
-RUN wget "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" \
- && unzip awscli-bundle.zip \
- && rm awscli-bundle.zip \
- && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws \
- && rm -r ./awscli-bundle
+RUN apk add --no-cache aws-cli 
 COPY raddb.sh /raddb.sh
 RUN chmod +x /raddb.sh
 ENTRYPOINT ["/raddb.sh"]


### PR DESCRIPTION
### What
Fix critical issue with radius docker image

### Why
The Dockerfile.raddb that we use to create the ECR image that our radius tasks boot from, was erroring when unzipping this package: awscli-bundle/packages/setup/wheel-0.33.6.tar.gz

Error occurred whenever a build of the docker image was attempted. This was caused by an outdated version of the aws-cli. I have updated the aws-cli to version 2, which has solved the issue.  Installing with curl/wget was cumbersome, so this has been changed to use the official alpine version of aws-cli with the apk add command instead.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-919
