### PR TITLE
Remove verify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk --update --no-cache add wpa_supplicant openssl make gcc libc-dev curl ta
 RUN wget https://github.com/FreeRADIUS/freeradius-server/releases/download/release_3_2_2/freeradius-server-3.2.2.tar.gz \
     && tar xzvf freeradius-server-3.2.2.tar.gz \
     && cd freeradius-server-3.2.2 \
-    && ./configure --sysconfdir=/etc \
+    && ./configure CPPFLAGS=-DX509_V_FLAG_PARTIAL_CHAIN=1 --sysconfdir=/etc \
     && make \
     && make install
 RUN rm -rf ./freeradius-server-3.2.2

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,7 @@ copy_certs:
 
 	mkdir -p $(TRUSTED_CERTIFICATES_PATH)
 
-	# cp $(CERTIFICATE_PATH)/separate_intermediate_ca.pem $(TRUSTED_CERTIFICATES_PATH)/separate_intermediate_ca.pem
 	cp $(CERTIFICATE_PATH)/intermediate_ca.pem $(TRUSTED_CERTIFICATES_PATH)/intermediate_ca.pem
-	cp $(CERTIFICATE_PATH)/root_ca.pem $(TRUSTED_CERTIFICATES_PATH)/root_ca.pem
 
 rehash_certs:
 	c_rehash $(TRUSTED_CERTIFICATES_PATH)

--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -21,11 +21,6 @@
 				max_entries = 255
 			}
 
-			verify {
-				tmpdir = /tmp/radiusd
-				client = "/usr/bin/openssl verify -CApath ${certdir}/trusted_certificates %{TLS-Client-Cert-Filename}"
-			}
-
 			ocsp {
 				enable = no
 				override_cert_url = yes


### PR DESCRIPTION
Remove the 'verify' directive in the FreeRadius configuration

This dramatically increases performance when authenticate EAP-TLS
based clients. The directive spawns a new OpenSSL process for each
authentication, which is very inefficient and not strictly
necessary.

 When compiling FreeRadius, we set the X509_V_FLAG_PARTIAL_CHAIN
  preprocessor flag. This causes intermediate certificates in the
  trust store to be treated as trust-anchors, in the same way as
  self-signed root CA certificates.

  So if we want to limit the certificates that are accepted to ones
  that have been issued by a specific intermediate certificate, we
  need to make sure that that certificate is the only one in the
  trust store.

Jira: https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1379

  In the tests we therefore need to remove the root certificate from
  the trust store so we don't accept client certificates issued by
  other branches in the PKI.