### PR TITLE
Fix errors in Frontend related to changes in Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.2.2-alpine
 RUN apk --update --no-cache add wpa_supplicant openssl make gcc libc-dev curl talloc-dev jq g++ zlib-dev \
                                 openssl-dev linux-headers python3 py3-pip py3-wheel net-tools tmux sqlite-libs \
                                 sqlite sqlite-dev libxml2 curl-dev json-c-dev libmemcached-dev \
-                                mariadb-connector-c-dev
+                                mariadb-connector-c-dev py-watchdog
 
 RUN wget https://github.com/FreeRADIUS/freeradius-server/releases/download/release_3_2_2/freeradius-server-3.2.2.tar.gz \
     && tar xzvf freeradius-server-3.2.2.tar.gz \
@@ -25,8 +25,7 @@ RUN curl https://github.com/bvantagelimited/freeradius_exporter/releases/downloa
  && tar -xzvf freeradius_exporter.tar.gz --strip-components=1 freeradius_exporter-0.1.6-amd64/freeradius_exporter \
  && mv freeradius_exporter /usr/sbin/freeradius_exporter \
  && chmod 755 /usr/sbin/freeradius_exporter
- 
-RUN pip3 install watchdog==2.1.9
+
 COPY config_watch.py /usr/bin
 COPY scripts/run*.sh scripts/db_utils.sh scripts/vars.sh /usr/bin/
 RUN chmod 755 /usr/bin/*.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,12 @@ RUN chmod 755 /usr/bin/*.sh
 
 COPY api-stubs /api-stubs
 WORKDIR /api-stubs
+RUN bundle config force_ruby_platform true
 RUN bundle install
 
 COPY test-app /test-app
 WORKDIR /test-app
+RUN bundle config force_ruby_platform true
 RUN bundle install
 
 COPY healthcheck /healthcheck

--- a/api-stubs/Gemfile
+++ b/api-stubs/Gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 ruby File.read(".ruby-version").chomp
 
 gem "puma"
-gem "sqlite3"
+gem "sqlite3", force_ruby_platform: true
 gem "sequel"
 gem "sinatra"
 gem "rspec"

--- a/test-app/Gemfile
+++ b/test-app/Gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 ruby File.read(".ruby-version").chomp
 
 gem "puma"
-gem "sqlite3"
+gem "sqlite3", force_ruby_platform: true
 gem "sequel"
 gem "sinatra"
 gem "rspec"


### PR DESCRIPTION
Ensure the native extensions of the Sqlite3 gem are compiled

Due to a breaking change in the musl package, these now need
to be compiled from source

Use platform version of Python's Watchdog library